### PR TITLE
Patched Diamond spinner glitch on iOS

### DIFF
--- a/src/Diamonds.svelte
+++ b/src/Diamonds.svelte
@@ -17,7 +17,7 @@
     width: calc(var(--size) / 4);
     height: calc(var(--size) / 4);
     position: absolute;
-    left: 0;
+    left: 0%;
     top: 0;
     border-radius: 2px;
     background: var(--color);


### PR DESCRIPTION
On iOS browsers (e.g. Chrome and Safari), the animation from left: 0 -> left: 50% does not get handled correctly. Adding the percent sign fixes this.