### PR TITLE
Updated Stretch.svelte to start with scaleY

### DIFF
--- a/src/Stretch.svelte
+++ b/src/Stretch.svelte
@@ -23,6 +23,7 @@
     width: 10%;
     display: inline-block;
     margin-right: 4px;
+    transform: scaleY(0.4);
     background-color: var(--color);
     animation: stretch var(--duration) ease-in-out infinite;
   }


### PR DESCRIPTION
This makes sure when the animation starts the rectangles are not at full size, as te animation will cut them all down instantly to a lower transform. When the animation starts, this looks a bit weird.