### PR TITLE
Add patch script for resolves issue-52

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/kit": "next",
 		"@sveltejs/package": "next",
+		"@types/node": "^20.11.20",
 		"@typescript-eslint/eslint-plugin": "^5.27.0",
 		"@typescript-eslint/parser": "^5.27.0",
 		"eslint": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 	],
 	"scripts": {
 		"dev": "vite dev",
-		"build": "svelte-kit sync && svelte-package",
+		"build": "svelte-kit sync && svelte-package && npm run patch",
+		"patch": "npx tsx scripts/patch-package.ts",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-loading-spinners",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/schum123/svelte-loading-spinners.git"

--- a/scripts/patch-package.ts
+++ b/scripts/patch-package.ts
@@ -1,0 +1,16 @@
+import { writeFile } from 'node:fs/promises';
+import packageJson from '../package/package.json';
+
+const json = {
+	...packageJson,
+	svelte: undefined,
+	exports: {
+		...packageJson.exports,
+		'.': {
+			svelte: './index.js',
+			default: './index.js'
+		}
+	}
+};
+
+await writeFile('package/package.json', JSON.stringify(json, null, 2));


### PR DESCRIPTION
close #52

This PR modifies the `npm run build` script and applies a monkey patch for resolves #52.
This will remove the `svelte` field from the generated `package.json`.
This includes adding a dependency to `devDependencies` and adding the `npm run patch` script.
The changes have been tested with a local `npm run build`.
